### PR TITLE
feat: Add queue management and auto-play functionality

### DIFF
--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -8,15 +8,22 @@ import { searchTracks } from "@/lib/api"
 import { Track } from "@/lib/types"
 import { usePlayer } from "@/contexts/player-context"
 import { Button } from "@/components/ui/button"
-import { Play, Pause, Heart } from "lucide-react"
+import { Play, Pause, Heart, MoreHorizontal, ListPlus, PlayCircle } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { toast } from "sonner"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 function SearchResults() {
   const searchParams = useSearchParams()
   const query = searchParams.get("q")
   const [results, setResults] = useState<Track[]>([])
   const [isLoading, setIsLoading] = useState(false)
-  const { playTrack, currentTrack, isPlaying, togglePlay } = usePlayer()
+  const { playTrack, currentTrack, isPlaying, togglePlay, addToQueue, playNext } = usePlayer()
 
   useEffect(() => {
     const fetchResults = async () => {
@@ -83,7 +90,8 @@ function SearchResults() {
                         if (currentTrack?.id === track.id) {
                           togglePlay()
                         } else {
-                          playTrack(track)
+                          // Play this track and queue the rest of the results
+                          playTrack(track, results.slice(index + 1))
                         }
                       }}
                     >
@@ -113,10 +121,35 @@ function SearchResults() {
                     {track.genre || "Unknown Genre"}
                   </div>
 
-                  <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-2">
                     <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-primary">
                       <Heart className="h-4 w-4" />
                     </Button>
+                    
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground">
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => {
+                          playNext(track)
+                          toast.success("Added to play next")
+                        }}>
+                          <PlayCircle className="mr-2 h-4 w-4" />
+                          Play Next
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => {
+                          addToQueue(track)
+                          toast.success("Added to queue")
+                        }}>
+                          <ListPlus className="mr-2 h-4 w-4" />
+                          Add to Queue
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+
                     <div className="text-sm text-muted-foreground w-12 text-right">
                       {formatDuration(track.duration)}
                     </div>

--- a/frontend/components/home/quick-picks.tsx
+++ b/frontend/components/home/quick-picks.tsx
@@ -47,14 +47,14 @@ export function QuickPicks() {
 
   const handlePlayAll = () => {
     if (tracks.length > 0) {
-      playTrack(tracks[0])
+      playTrack(tracks[0], tracks.slice(1))
     }
   }
 
   const handleShuffle = () => {
     if (tracks.length > 0) {
-      const randomIndex = Math.floor(Math.random() * tracks.length)
-      playTrack(tracks[randomIndex])
+      const shuffled = [...tracks].sort(() => Math.random() - 0.5)
+      playTrack(shuffled[0], shuffled.slice(1))
     }
   }
 
@@ -105,11 +105,11 @@ export function QuickPicks() {
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {tracks.map((track) => (
+        {tracks.map((track, index) => (
           <QuickPickCard 
             key={track.id} 
             track={track} 
-            onPlay={() => playTrack(track)}
+            onPlay={() => playTrack(track, tracks.slice(index + 1))}
             isPlaying={currentTrack?.id === track.id && isPlaying}
           />
         ))}

--- a/frontend/components/home/recently-played.tsx
+++ b/frontend/components/home/recently-played.tsx
@@ -142,11 +142,11 @@ export function RecentlyPlayed() {
       </div>
       <ScrollArea className="w-full">
         <div className="flex gap-4 pb-4">
-          {recentTracks.map((track) => (
+          {recentTracks.map((track, index) => (
             <RecentTrackCard 
               key={`${track.id}-${track.played_at}`} 
               track={track} 
-              onPlay={() => playTrack(track)}
+              onPlay={() => playTrack(track, recentTracks.slice(index + 1))}
               isPlaying={currentTrack?.id === track.id && isPlaying}
             />
           ))}

--- a/frontend/components/player/music-player-bar.tsx
+++ b/frontend/components/player/music-player-bar.tsx
@@ -38,6 +38,8 @@ export function MusicPlayerBar() {
     seek,
     setVolume,
     toggleMute,
+    nextTrack,
+    previousTrack,
   } = usePlayer()
 
   // Don't render if no track is selected
@@ -117,7 +119,7 @@ export function MusicPlayerBar() {
               variant="ghost"
               size="icon"
               className="h-8 w-8 text-muted-foreground hover:text-foreground"
-              disabled
+              onClick={previousTrack}
             >
               <SkipBack className="h-4 w-4" />
             </Button>
@@ -144,7 +146,7 @@ export function MusicPlayerBar() {
               variant="ghost"
               size="icon"
               className="h-8 w-8 text-muted-foreground hover:text-foreground"
-              disabled
+              onClick={nextTrack}
             >
               <SkipForward className="h-4 w-4" />
             </Button>

--- a/frontend/components/player/play-button.tsx
+++ b/frontend/components/player/play-button.tsx
@@ -7,11 +7,12 @@ import { Track } from '@/lib/types'
 
 interface PlayButtonProps {
   track: Track
+  queue?: Track[]
   size?: 'sm' | 'md' | 'lg'
   className?: string
 }
 
-export function PlayButton({ track, size = 'md', className = '' }: PlayButtonProps) {
+export function PlayButton({ track, queue, size = 'md', className = '' }: PlayButtonProps) {
   const { currentTrack, isPlaying, isLoading, playTrack, togglePlay } = usePlayer()
 
   const isCurrentTrack = currentTrack?.id === track.id
@@ -24,7 +25,7 @@ export function PlayButton({ track, size = 'md', className = '' }: PlayButtonPro
     if (isCurrentTrack) {
       togglePlay()
     } else {
-      playTrack(track)
+      playTrack(track, queue)
     }
   }
 

--- a/frontend/components/player/track-list.tsx
+++ b/frontend/components/player/track-list.tsx
@@ -57,7 +57,7 @@ export function TrackList({ tracks }: TrackListProps) {
                 )}
               </span>
               <div className="hidden group-hover:block">
-                <PlayButton track={track} size="sm" />
+                <PlayButton track={track} queue={tracks.slice(index + 1)} size="sm" />
               </div>
             </div>
 

--- a/frontend/components/search-bar.tsx
+++ b/frontend/components/search-bar.tsx
@@ -56,7 +56,9 @@ export function SearchBar() {
   }, [query])
 
   const handlePlay = (track: Track) => {
-    playTrack(track)
+    const index = results.findIndex(t => t.id === track.id)
+    const newQueue = index !== -1 ? results.slice(index + 1) : []
+    playTrack(track, newQueue)
     setShowResults(false)
     setQuery("")
   }


### PR DESCRIPTION
## Description
This PR introduces a robust queue management system to the music player, enabling "Play Next", "Add to Queue", and automatic playback of subsequent tracks.

## Key Changes

### Player Context
- **Queue State**: Added `queue` and `history` state management to `PlayerContext`.
- **New Actions**: Implemented `addToQueue`, `playNext`, `nextTrack`, `previousTrack`, and `clearQueue`.
- **Auto-Play**: Updated the `ended` event listener to automatically play the next track in the queue.
- **Smart Playback**: `playTrack` now accepts an optional `newQueue` parameter to populate the queue with context-aware tracks (e.g., the rest of a search result list).

### UI Enhancements
- **Music Player Bar**: Enabled "Skip Forward" and "Skip Back" buttons to navigate the queue and history.
- **Search Page**: Added a dropdown menu to track items with "Play Next" and "Add to Queue" options.
- **Play Buttons**: Updated play buttons across the app (Search, Quick Picks, Recently Played) to automatically queue the remaining tracks in the list when clicked.

## How to Test
1. **Auto-Play**: Play a track from a list (e.g., Search Results). Let it finish or scrub to the end. Verify the next track in the list starts playing automatically.
2. **Queue Actions**: 
   - Search for a track.
   - Click the three dots menu.
   - Select "Add to Queue".
   - Verify the track plays after the current queue finishes (or use the Next button to reach it).
3. **Navigation**: Use the Next/Previous buttons in the player bar to skip through tracks.